### PR TITLE
Fix build issue on C++-based test cases

### DIFF
--- a/lfbb/inc/lfbb.h
+++ b/lfbb/inc/lfbb.h
@@ -44,7 +44,6 @@
 #ifndef LFBB_H
 #define LFBB_H
 
-#include <stdatomic.h>
 #include <stdint.h>
 #include <stdlib.h>
 #ifndef __cplusplus


### PR DESCRIPTION
## Summary
This PR intends to fix a compiler error when building the test cases due to the C++ compiler failing to include the `stdatomic.h` C header.

## Testing
```sh
cmake -B.build/ tests/
cmake --build .build/
```
```sh
Consolidate compiler generated dependencies of target tests                                                                                  
[ 99%] Building CXX object CMakeFiles/tests.dir/tests.cpp.o                                                                                  
In file included from /home/nihei/Projects/lfbb/lfbb/inc/lfbb.h:47,                                                                          
                 from /home/nihei/Projects/lfbb/tests/tests.cpp:3:                                                                           
/usr/lib/gcc/x86_64-linux-gnu/11/include/stdatomic.h:40:9: error: ‘_Atomic’ does not name a type                                             
   40 | typedef _Atomic _Bool atomic_bool;
      |         ^~~~~~~                   
/usr/lib/gcc/x86_64-linux-gnu/11/include/stdatomic.h:41:9: error: ‘_Atomic’ does not name a type                                             
   41 | typedef _Atomic char atomic_char;                                                                                                    
      |         ^~~~~~~                                                                                                                      
/usr/lib/gcc/x86_64-linux-gnu/11/include/stdatomic.h:42:9: error: ‘_Atomic’ does not name a type
   42 | typedef _Atomic signed char atomic_schar;
      |         ^~~~~~~
```
